### PR TITLE
fix: replace postinstall with prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "preinstall": "npx only-allow pnpm",
     "np": "pnpm build && np --no-cleanup ",
     "test": "echo \"no test specified\"",
-    "postinstall": "husky install"
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Replace postinstall with prepare to avoid installing package dev dependencies in client project