### PR TITLE
Refactor publish package to npm workflow 

### DIFF
--- a/.github/workflows/publish-pkg.yaml
+++ b/.github/workflows/publish-pkg.yaml
@@ -5,13 +5,16 @@ on:
     inputs:
       release-type:
         type: choice
-        description: 'Release type (one of): patch, minor, major'
+        description: 'Release type (one of): patch, minor, major,prepatch, preminor, premajor'
         required: true
         default: 'patch'
         options:
           - patch
           - minor
           - major
+          - prepatch
+          - preminor
+          - premajor
 
 jobs:
   release:
@@ -25,39 +28,31 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: echo "GH_TOKEN=${GITHUB_TOKEN}" >> $GITHUB_ENV
-      - name : 📦 Checkout project repo
+      - name: 📦 Checkout project repo
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: master
-          token : ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: 📝 Git User Setup
         run: |
-          git config --global user.email "github-actions@github.com"
-          git config --global user.name "GitHub Actions"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
 
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: 'yarn'
-
-      - name: 📦 Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - name: 📦 Restore Project Dependencies (node_modules)
-        uses: actions/cache@v3
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: 'pnpm'
 
       - name: 📦 Install Project Dependencies
-        run: yarn install --immutable
+        run: pnpm install --frozen-lockfile
 
       - name: 🏃‍♂️ Run np release
         run: |
-          yarn np-release ${{ github.event.inputs.release-type }} --no-release-draft
+          pnpm run np ${{ github.event.inputs.release-type }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "ts-node example/index.ts",
     "type-check": "tsc --noEmit",
     "preinstall": "npx only-allow pnpm",
-    "np": "pnpm build && np --no-cleanup ",
+    "np": "pnpm build && np --no-cleanup --no-release-draft",
     "test": "echo \"no test specified\"",
     "prepare": "husky install"
   },


### PR DESCRIPTION
The PRs improve and fix the publishing of the package to npm by:

* Adding the correct git name and email to connect the tag with the correct GitHub action bot
* Removing publishing a GitHub release using `np`, we will create it manually using the new automated release notes by GitHub (better) 
* Adding messed  release types
* Adding an NPM token
* Migrating the workflow from `yarn` to `pnpm`

ACTIONS REQUIRED: @SihamBen 
* Adding the missed `NODE_AUTH_TOKEN`  secrets to GitHub to push the package to npm [here](https://docs.npmjs.com/creating-and-viewing-access-tokens); make sure to choose type automation
* Generating and adding `GH_TOKEN` secrets to GitHub as we need it to push the version commit by the action (required if you are activating branch protection) [here](https://til.cazzulino.com/devops-ci-cd/push-to-protected-branch-from-github-actions)