### PR TITLE
Refactor expo plugin logic for more simple setup

### DIFF
--- a/app.plugin.ts
+++ b/app.plugin.ts
@@ -1,33 +1,43 @@
 import { addBadge } from './index';
+import { Badge } from './types';
+
+const DST_APP_ICON_BADGE_FOLDER = '.expo/app-icon-badge';
+const DST_ICON = `${DST_APP_ICON_BADGE_FOLDER}/icon.png`;
+const DST_ADAPTIVE_APP_ICON = `${DST_APP_ICON_BADGE_FOLDER}/foregroundImage.png`;
 
 type Params = {
-  icon: string;
-  environment?: string;
-  dstPath?: string;
+  badges: Array<Badge>;
   enabled?: boolean;
 };
-function withIconBadge(
-  config: any,
-  { environment, icon, dstPath, enabled = true }: Params
-) {
+
+function withIconBadge(config: any, { badges, enabled = true }: Params) {
   if (!enabled) return config;
 
+  // get source paths from config
+  const iconPath = config?.icon;
+  const adaptiveIconPath = config?.android?.adaptiveIcon?.foregroundImage;
+  // TODO: add more checks for the config object
+
+  // Generate icon with badge
+  // normally addBadge is async but we don't need to wait for it also not sure how to use async in this context
   addBadge({
-    icon: icon,
-    dstPath: dstPath,
-    badges: [
-      {
-        type: 'ribbon',
-        text: config.version,
-      },
-      {
-        type: 'banner',
-        text: environment || '',
-      },
-    ],
+    icon: iconPath,
+    dstPath: DST_ICON,
+    badges,
   });
+
+  // waiting for the adaptive icon support here
+  addBadge({
+    icon: adaptiveIconPath,
+    dstPath: DST_ADAPTIVE_APP_ICON,
+    badges,
+  });
+
+  // replace config paths with the new ones
+  config.icon = DST_ICON;
+  config.android.adaptiveIcon.foregroundImage = DST_ADAPTIVE_APP_ICON;
 
   return config;
 }
 module.exports = withIconBadge;
-// TODO: Add TYPING for the config object
+// TODO: Add More TYPING for the config object

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "app.plugin.js"
   ],
   "scripts": {
-    "build": "tsup index.ts --format cjs,esm --dts && cp -r assets dist && tsup app.plugin.ts --format cjs,esm  && cp -r  dist/app.plugin.js .",
+    "build": "tsup index.ts  --format cjs,esm --dts && cp -r assets dist && tsup app.plugin.ts --format cjs  && mv   dist/app.plugin.js .",
     "start": "nodemon --exec ts-node --files example/index.ts",
     "type-check": "tsc --noEmit",
     "format": "prettier --write \"**/*.{ts,md,json}\" --ignore-path .gitignore",

--- a/types.ts
+++ b/types.ts
@@ -1,3 +1,5 @@
+import exp from 'constants';
+
 export type Banner = {
   type: 'banner';
   text: string;
@@ -14,8 +16,10 @@ export type Ribbon = {
   background?: string;
 };
 
+export type Badge = Banner | Ribbon;
+
 export type Params = {
   icon: string;
   dstPath?: string;
-  badges: Array<Banner | Ribbon>;
+  badges: Array<Badge>;
 };


### PR DESCRIPTION
Refactor the plugin to make it easy to use.

Users will mainly add the original and adaptive icons to the app configuration. The plugin will check for the path, create new images, and save them in the `.expo` folder. It will then replace the icon with the new one.