### PR TITLE
fix: add try catch to prevent error on android build phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ node_modules/
 assets/*.*.png
 example/*.*.png
 dist
-app.plugin.js
 .DS_Store

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/app.plugin.js');

--- a/app.plugin.ts
+++ b/app.plugin.ts
@@ -13,34 +13,37 @@ type Params = {
 function withIconBadge(config: any, { badges, enabled = true }: Params) {
   if (!enabled) return config;
 
-  // get source paths from config
-  const iconPath = config?.icon;
-  const adaptiveIconPath = config?.android?.adaptiveIcon?.foregroundImage;
-  // TODO: add more checks for the config object
+  try {
+    // get source paths from config
+    const iconPath = config?.icon;
+    const adaptiveIconPath = config?.android?.adaptiveIcon?.foregroundImage;
+    // TODO: add more checks for the config object
 
-  // Generate icon with badge
-  // normally addBadge is async but we don't need to wait for it also not sure how to use async in this context
-  if (iconPath) {
-    addBadge({
-      icon: iconPath,
-      dstPath: DST_ICON,
-      badges,
-    });
-    config.icon = DST_ICON;
+    // Generate icon with badge
+    // normally addBadge is async but we don't need to wait for it also not sure how to use async in this context
+    if (iconPath) {
+      addBadge({
+        icon: iconPath,
+        dstPath: DST_ICON,
+        badges,
+      });
+      config.icon = DST_ICON;
+    }
+
+    // waiting for the adaptive icon support here
+    if (adaptiveIconPath) {
+      addBadge({
+        isAdaptiveIcon: true,
+        icon: adaptiveIconPath,
+        dstPath: DST_ADAPTIVE_APP_ICON,
+        badges,
+      });
+      config.android.adaptiveIcon.foregroundImage = DST_ADAPTIVE_APP_ICON;
+    }
+
+    return config;
+  } catch (error) {
+    return config;
   }
-
-  // waiting for the adaptive icon support here
-  if (adaptiveIconPath) {
-    addBadge({
-      isAdaptiveIcon: true,
-      icon: adaptiveIconPath,
-      dstPath: DST_ADAPTIVE_APP_ICON,
-      badges,
-    });
-    config.android.adaptiveIcon.foregroundImage = DST_ADAPTIVE_APP_ICON;
-  }
-
-  return config;
 }
 module.exports = withIconBadge;
-// TODO: Add More TYPING for the config object

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "app.plugin.js"
   ],
   "scripts": {
-    "build": "tsup index.ts  --format cjs,esm --dts && cp -r assets dist && tsup app.plugin.ts --format cjs  && mv   dist/app.plugin.js .",
+    "build": "tsup index.ts  --format cjs,esm --dts && cp -r assets dist && tsup app.plugin.ts --format cjs ",
     "start": "nodemon --exec ts-node --files example/index.ts",
     "type-check": "tsc --noEmit",
     "format": "prettier --write \"**/*.{ts,md,json}\" --ignore-path .gitignore",


### PR DESCRIPTION
* A simple fix to silent error on android build phase and fix #25   By wrapping the plugin logic with a try-catch block.
* A simple update on the plugin file to prevent copying files on the build phase